### PR TITLE
Edit deprecated codes to compatible with the PHP 7.4

### DIFF
--- a/HTTP2.php
+++ b/HTTP2.php
@@ -498,12 +498,12 @@ location.replace("'.str_replace('"', '\\"', $url).'");
         } else {
             $uriBase = $uriAll;
         }
-        if (!strlen($url) || $url{0} == '#') {
+        if (!strlen($url) || $url[0] == '#') {
             $url = $uriAll.$url;
-        } elseif ($url{0} == '?') {
+        } elseif ($url[0] == '?') {
             $url = $uriBase.$url;
         }
-        if ($url{0} == '/') {
+        if ($url[0] == '/') {
             return $server . $url;
         }
 
@@ -554,10 +554,10 @@ location.replace("'.str_replace('"', '\\"', $url).'");
             while ($pos < $len - 1) {
                 $link = array();
                 $pos = $len - strlen(ltrim(substr($line, $pos)));
-                if ($line{$pos} == ',') {
+                if ($line[$pos] == ',') {
                     ++$pos;
                     continue;
-                } else if ($line{$pos} != '<') {
+                } else if ($line[$pos] != '<') {
                     break;
                 }
                 $end = strpos($line, '>', $pos + 1);
@@ -568,12 +568,12 @@ location.replace("'.str_replace('"', '\\"', $url).'");
                 $pos = $end + 1;
 
                 while ($pos < $len - 1) {
-                    if ($line{$pos} == ',') {
+                    if ($line[$pos] == ',') {
                         $extracted[] = $link;
                         $link = array();
                         ++$pos;
                         continue;
-                    } else if ($line{$pos} != ';') {
+                    } else if ($line[$pos] != ';') {
                         break;
                     }
 
@@ -586,7 +586,7 @@ location.replace("'.str_replace('"', '\\"', $url).'");
                     $pos = $end + 1;
                     
                     $rest = trim(substr($line, $pos));
-                    if ($rest{0} == '"') {
+                    if ($rest[0] == '"') {
                         $pos = strpos($line, '"', $pos) + 1;
                         $end = strpos($line, '"', $pos + 1);
                         $pval = substr($line, $pos, $end - $pos);
@@ -626,7 +626,7 @@ location.replace("'.str_replace('"', '\\"', $url).'");
                     } else if (!isset($link[$pname])) {
                         $link[$pname] = $pval;
                     }
-                    if ($end >= $len || $line{$end} == ',') {
+                    if ($end >= $len || $line[$end] == ',') {
                         break;
                     }
                 }


### PR DESCRIPTION
Replace offset access to strings and arrays with curly braces by brackets. From PHP 7.4, array and string offset access syntax with curly braces is deprecated. To fix errors due to this deprecation, we should replace curly braces by brackets.